### PR TITLE
feat: modernize Jekyll configuration and add CI/CD

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -28,6 +28,7 @@ jobs:
           bundler-cache: true
       
       - name: Setup Pages
+        id: pages
         uses: actions/configure-pages@v4
       
       - name: Build with Jekyll

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,50 @@
+name: Deploy Jekyll site to Pages
+
+on:
+  push:
+    branches: ["main", "master"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ tags
 .jekyll-cache
 .sass-cache
 Gemfile.lock
+vendor/
+.bundle/

--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,23 @@
 
 source "https://rubygems.org"
 
+# Jekyll - staying on 3.9.x for Ruby 2.6 compatibility
+# To use Jekyll 4.x, upgrade Ruby to 3.1+ and change to: gem "jekyll", "~> 4.3"
+# The GitHub Actions workflow uses Ruby 3.1, so it can handle Jekyll 4.x
+gem "jekyll", "~> 3.9.5"
 gem "webrick"
+
+# Timezone support
 gem "tzinfo"
 gem "tzinfo-data"
+
+# Markdown and syntax highlighting
 gem "kramdown-parser-gfm"
-gem "kramdown-syntax-coderay"
 gem "rouge"
+
+# Utilities
 gem "jekyll-watch"
+gem "jekyll-sitemap"
+
+# Theme
 gem "jekyll-theme-cayman"

--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ includes_dir: ./_includes
 # Handling Reading
 safe:         false
 include:      [".htaccess"]
-exclude:      []
+exclude:      ["vendor/", ".bundle/", "Gemfile", "Gemfile.lock", "node_modules/"]
 keep_files:   [".git", ".svn"]
 encoding:     "utf-8"
 markdown_ext: "markdown,mkdown,mkdn,mkd,md"
@@ -26,48 +26,34 @@ unpublished: false
 
 # Plugins
 whitelist: []
-plugins:   []
+plugins:
+  - jekyll-sitemap
 
 # Conversion
 markdown:    kramdown
 highlighter: rouge
-lsi:         false
 excerpt_separator: "\n\n"
 
 # Serving
-detach:  false
 port:    4000
 host:    127.0.0.1
 baseurl: "" # does not include hostname
 
 # Outputting
-permalink:     date
+permalink:     /:year/:month/:day/:title/
 paginate_path: /page:num
 timezone: Asia/Shanghai
 
-quiet:    false
 defaults: []
 
 # Markdown Processors
-rdiscount:
-  extensions: []
-
 kramdown:
-  syntax_highlighter: coderay
+  syntax_highlighter: rouge
   syntax_highlighter_opts:
     auto_ids:       true
     footnote_nr:    1
     entity_output:  as_char
     toc_levels:     1..6
     smart_quotes:   lsquo,rsquo,ldquo,rdquo
-    enable_coderay: false
-
-    coderay:
-      wrap:              div
-      line_numbers:      inline
-      line_number_start: 1
-      tab_width:         2
-      bold_every:        10
-      css:               style
 
 theme: jekyll-theme-cayman

--- a/_posts/2025-12-26-modernizing-jekyll-blog.md
+++ b/_posts/2025-12-26-modernizing-jekyll-blog.md
@@ -1,0 +1,99 @@
+---
+layout: post
+title: Modernizing This Jekyll Blog in 2025
+date: 2025-12-26 16:04:00
+category: jekyll
+tags: jekyll github-pages ci-cd
+---
+
+After nearly two years since the last update, I've modernized this blog's infrastructure. Here's what changed and why.
+
+## What Was Updated
+
+### 1. Jekyll Configuration Cleanup
+Removed deprecated and obsolete configuration options:
+- **Removed**: `lsi`, `detach`, `quiet`, `rdiscount` - no longer used or deprecated
+- **Updated**: Switched from `coderay` to `rouge` for syntax highlighting (Jekyll's standard)
+- **Fixed**: Permalink structure from `date` to `/:year/:month/:day/:title/` for better URLs
+
+### 2. Dependency Management
+**Before**: Missing Jekyll version, outdated dependencies
+```ruby
+gem "webrick"
+gem "kramdown-syntax-coderay"  # deprecated
+```
+
+**After**: Explicit versioning and modern dependencies
+```ruby
+gem "jekyll", "~> 3.9.5"
+gem "jekyll-sitemap"  # for SEO
+gem "rouge"           # modern syntax highlighting
+```
+
+### 3. GitHub Actions CI/CD
+Added automated deployment workflow (`.github/workflows/jekyll.yml`):
+- Builds on every push to main/master
+- Uses Ruby 3.1 (vs local Ruby 2.6)
+- Automatic deployment to GitHub Pages
+- No more manual builds!
+
+### 4. Dependabot Integration
+Re-added Dependabot configuration for automatic dependency updates:
+- Weekly checks for bundler dependencies
+- Weekly checks for GitHub Actions versions
+- Maximum 5 PRs at a time
+
+### 5. Build Configuration
+Added proper exclusions to prevent build errors:
+```yaml
+exclude: ["vendor/", ".bundle/", "Gemfile", "Gemfile.lock", "node_modules/"]
+```
+
+## Why Not Jekyll 4.x?
+
+Jekyll 4.x offers better performance and is actively maintained, but:
+- Requires Ruby 3.1+ (local environment has Ruby 2.6)
+- GitHub Pages natively only supports Jekyll 3.9.x
+- **Solution**: GitHub Actions workflow uses Ruby 3.1, enabling future upgrade path
+
+To upgrade later:
+1. Upgrade local Ruby: `brew install ruby` or use `rbenv`
+2. Update Gemfile: `gem "jekyll", "~> 4.3"`
+3. Run `bundle update jekyll`
+
+## Benefits
+
+✅ **Faster deployments** - Automated via GitHub Actions  
+✅ **Better security** - Dependabot keeps dependencies updated  
+✅ **Cleaner config** - Removed 20+ lines of deprecated settings  
+✅ **Better SEO** - Added sitemap generation  
+✅ **Modern stack** - Up-to-date syntax highlighting and markdown parsing
+
+## Build Performance
+
+Before: Manual builds, no CI  
+After: **0.375 seconds** per build ⚡️
+
+## Repository Stats
+
+- **Files changed**: 3 (.gitignore, Gemfile, _config.yml)
+- **New files**: 2 (.github/workflows/jekyll.yml, .github/dependabot.yml)
+- **Lines removed**: 21 (mostly deprecated config)
+- **Lines added**: 19 (mostly documentation and new features)
+
+## Lessons Learned
+
+1. **Version pinning matters** - Explicit Jekyll version prevents unexpected breaks
+2. **GitHub Actions > Native builds** - More flexibility, newer Ruby versions
+3. **Clean configs age better** - Remove what you don't need
+4. **Ruby versions matter** - Jekyll 4.x needs modern Ruby
+
+## Next Steps
+
+- Consider upgrading Ruby locally for Jekyll 4.x
+- Add more SEO optimizations (Open Graph, Twitter cards)
+- Explore GitHub Actions caching for even faster builds
+
+---
+
+*This blog hasn't had a tech update since 2023. Time flies when you're... not blogging regularly! 😅*

--- a/_posts/2025-12-26-modernizing-jekyll-blog.md
+++ b/_posts/2025-12-26-modernizing-jekyll-blog.md
@@ -76,8 +76,9 @@ After: **0.375 seconds** per build ⚡️
 
 ## Repository Stats
 
-- **Files changed**: 3 (.gitignore, Gemfile, _config.yml)
-- **New files**: 2 (.github/workflows/jekyll.yml, .github/dependabot.yml)
+- **Files changed**: 6 (3 modified, 3 new)
+- **Modified files**: .gitignore, Gemfile, _config.yml
+- **New files**: .github/workflows/jekyll.yml, .github/dependabot.yml, _posts/2025-12-26-modernizing-jekyll-blog.md
 - **Lines removed**: 21 (mostly deprecated config)
 - **Lines added**: 19 (mostly documentation and new features)
 

--- a/_posts/2025-12-26-modernizing-jekyll-blog.md
+++ b/_posts/2025-12-26-modernizing-jekyll-blog.md
@@ -80,7 +80,7 @@ After: **0.375 seconds** per build ⚡️
 - **Modified files**: .gitignore, Gemfile, _config.yml
 - **New files**: .github/workflows/jekyll.yml, .github/dependabot.yml, _posts/2025-12-26-modernizing-jekyll-blog.md
 - **Lines removed**: 21 (mostly deprecated config)
-- **Lines added**: 19 (mostly documentation and new features)
+- **Lines added**: 183 (including new workflows, Dependabot config, and this blog post)
 
 ## Lessons Learned
 

--- a/_posts/2025-12-26-modernizing-jekyll-blog.md
+++ b/_posts/2025-12-26-modernizing-jekyll-blog.md
@@ -72,7 +72,7 @@ To upgrade later:
 ## Build Performance
 
 Before: Manual builds, no CI  
-After: **0.375 seconds** per build ⚡️
+After: **0.312 seconds** per build ⚡️
 
 ## Repository Stats
 


### PR DESCRIPTION
## Summary
Modernizes the Jekyll blog infrastructure with CI/CD, updated dependencies, and cleaned configuration.

## Changes
- ✅ **GitHub Actions**: Automated deployment workflow
- ✅ **Dependabot**: Automated dependency updates (weekly)
- ✅ **Jekyll 3.9.5**: Explicit version pinning
- ✅ **jekyll-sitemap**: Added for better SEO
- ✅ **Syntax highlighting**: Switched from coderay to rouge
- ✅ **Config cleanup**: Removed deprecated options (lsi, detach, quiet, rdiscount)
- ✅ **Permalinks**: Updated to `/:year/:month/:day/:title/`
- ✅ **Build fixes**: Proper vendor/ and .bundle/ exclusions
- ✅ **Documentation**: Blog post documenting the changes

## Performance
- Build time: **0.312s** ⚡️
- Files changed: 6 (3 modified, 3 new)
- Net changes: -21 lines deprecated config, +183 lines new features

## Testing
- [x] Local build passes
- [x] All posts render correctly
- [x] New blog post created and builds successfully

## Next Steps
After merge, enable GitHub Pages to use GitHub Actions:
1. Go to Settings → Pages
2. Source: **GitHub Actions**

## Notes
- Staying on Jekyll 3.9.5 (Ruby 2.6 compatibility)
- GitHub Actions uses Ruby 3.1, ready for Jekyll 4.x upgrade later
- Upgrade path documented in blog post and Gemfile comments