### PR TITLE
fix: update navigation links for Jekyll 4 directory structure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,6 @@
 
 source "https://rubygems.org"
 
-# Jekyll - staying on 3.9.x for Ruby 2.6 compatibility
-# To use Jekyll 4.x, upgrade Ruby to 3.1+ and change to: gem "jekyll", "~> 4.3"
-# The GitHub Actions workflow uses Ruby 3.1, so it can handle Jekyll 4.x
 gem "jekyll", "~> 4.4.1"
 gem "webrick"
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,34 +15,34 @@
 			{% if page.path == "archive.html" %}
 			<span class="title">
 				<li>
-					<a href="/archive.html">archive</a>
+					<a href="/archive/">archive</a>
 				</li>
 			</span>			
 			{% else %}
 				<li>
-					<a href="/archive.html">archive</a>
+					<a href="/archive/">archive</a>
 				</li>			
 			{% endif %}
 			{% if page.path == "category.html" %}
 			<span class="title">
 				<li>
-					<a href="/category.html">category</a>
+					<a href="/category/">category</a>
 				</li>
 			</span>			
 			{% else %}
 				<li>
-					<a href="/category.html">category</a>
+					<a href="/category/">category</a>
 				</li>			
 			{% endif %}
 			{% if page.path == "about.html" %}
 			<span class="title">
 				<li>
-					<a href="/about.html">about</a>
+					<a href="/about/">about</a>
 				</li>
 			</span>			
 			{% else %}
 				<li>
-					<a href="/about.html">about</a>
+					<a href="/about/">about</a>
 				</li>			
 			{% endif %}
 		</div>


### PR DESCRIPTION
## Problem
After upgrading to Jekyll 4.4.1, navigation links to about, archive, and category pages result in 404 errors.

Jekyll 4 changed how it generates HTML pages:
- **Jekyll 3**: `/about.html`, `/archive.html`, `/category.html`
- **Jekyll 4**: `/about/index.html`, `/archive/index.html`, `/category/index.html`

## Solution
Updated navigation links in `_includes/header.html` to use trailing slash URLs:
- `/about.html` → `/about/`
- `/archive.html` → `/archive/`
- `/category.html` → `/category/`

## Testing
- [x] Local build passes (0.273s)
- [x] Verified links in generated HTML point to correct URLs
- [x] Pages accessible at new URLs with trailing slash

## Impact
Fixes navigation menu links to work with Jekyll 4 directory structure.