### PR TITLE
docs: update modernization post with Jekyll 4 upgrade details

### DIFF
--- a/_posts/2025-12-26-modernizing-jekyll-blog.md
+++ b/_posts/2025-12-26-modernizing-jekyll-blog.md
@@ -51,15 +51,33 @@ exclude: ["vendor/", ".bundle/", "Gemfile", "Gemfile.lock", "node_modules/"]
 
 ## Why Not Jekyll 4.x?
 
-Jekyll 4.x offers better performance and is actively maintained, but:
-- Requires Ruby 3.1+ (local environment has Ruby 2.6)
-- GitHub Pages natively only supports Jekyll 3.9.x
-- **Solution**: GitHub Actions workflow uses Ruby 3.1, enabling future upgrade path
+~~Jekyll 4.x offers better performance and is actively maintained, but:~~
+- ~~Requires Ruby 3.1+ (local environment has Ruby 2.6)~~
+- ~~GitHub Pages natively only supports Jekyll 3.9.x~~
+- ~~**Solution**: GitHub Actions workflow uses Ruby 3.1, enabling future upgrade path~~
 
-To upgrade later:
-1. Upgrade local Ruby: `brew install ruby` or use `rbenv`
-2. Update Gemfile: `gem "jekyll", "~> 4.3"`
-3. Run `bundle update jekyll`
+~~To upgrade later:~~
+1. ~~Upgrade local Ruby: `brew install ruby` or use `rbenv`~~
+2. ~~Update Gemfile: `gem "jekyll", "~> 4.3"`~~
+3. ~~Run `bundle update jekyll`~~
+
+**Update**: We went ahead and upgraded to Jekyll 4.4.1! 🎉
+
+### The Upgrade Process
+
+1. **Upgraded Ruby locally**: Installed Ruby 3.4.8 via Homebrew
+2. **Dependabot helped**: Automatically created PR to update Jekyll to 4.4.1
+3. **Fixed navigation links**: Jekyll 4 generates pages as directories (`/about/` instead of `/about.html`)
+
+### What Changed in Jekyll 4
+
+- **Page URLs**: Jekyll 4 creates directory structures with `index.html` files
+  - Before: `/about.html`, `/archive.html`, `/category.html`
+  - After: `/about/index.html`, `/archive/index.html`, `/category/index.html`
+  - Fixed navigation links to use trailing slash URLs
+- **Better performance**: Faster builds and improved caching
+- **Modern dependencies**: Updated sass-embedded and other gems
+- **Build time**: Still fast at ~0.3 seconds ⚡️
 
 ## Benefits
 
@@ -76,24 +94,36 @@ After: **0.312 seconds** per build ⚡️
 
 ## Repository Stats
 
-- **Files changed**: 6 (3 modified, 3 new)
-- **Modified files**: .gitignore, Gemfile, _config.yml
+- **Files changed**: 7 (4 modified, 3 new)
+- **Modified files**: .gitignore, Gemfile, _config.yml, _includes/header.html
 - **New files**: .github/workflows/jekyll.yml, .github/dependabot.yml, _posts/2025-12-26-modernizing-jekyll-blog.md
 - **Lines removed**: 21 (mostly deprecated config)
-- **Lines added**: 183 (including new workflows, Dependabot config, and this blog post)
+- **Lines added**: 189 (including new workflows, Dependabot config, and this blog post)
+- **Dependabot PRs**: 2 auto-merged (Jekyll 4.4.1 upgrade, GitHub Actions updates)
 
 ## Lessons Learned
 
 1. **Version pinning matters** - Explicit Jekyll version prevents unexpected breaks
 2. **GitHub Actions > Native builds** - More flexibility, newer Ruby versions
 3. **Clean configs age better** - Remove what you don't need
-4. **Ruby versions matter** - Jekyll 4.x needs modern Ruby
+4. **Ruby versions matter** - Jekyll 4.x needs modern Ruby (upgraded from 2.6 to 3.4)
+5. **Dependabot is worth it** - Automated the Jekyll 4 upgrade seamlessly
+6. **Test locally** - Jekyll 4's directory structure change broke navigation links initially
+
+## Timeline
+
+- **Initial modernization**: Configuration cleanup, CI/CD setup, Dependabot
+- **+3 hours**: Dependabot automatically upgraded Jekyll to 4.4.1
+- **+30 minutes**: Upgraded local Ruby 3.4.8, fixed navigation links for Jekyll 4
+- **Result**: Fully automated, modern Jekyll 4 blog with CI/CD
 
 ## Next Steps
 
-- Consider upgrading Ruby locally for Jekyll 4.x
+- ~~Consider upgrading Ruby locally for Jekyll 4.x~~ ✅ Done! (Ruby 3.4.8)
+- ~~Upgrade to Jekyll 4.x~~ ✅ Done! (Jekyll 4.4.1)
 - Add more SEO optimizations (Open Graph, Twitter cards)
 - Explore GitHub Actions caching for even faster builds
+- Update README with better documentation ✅ Done!
 
 ---
 


### PR DESCRIPTION
## Summary
Updates the modernization blog post to reflect the successful Jekyll 4.4.1 upgrade and all related improvements.

## Changes
- ✅ Document Jekyll 4.4.1 upgrade (via Dependabot PR)
- ✅ Document Ruby 3.4.8 upgrade process
- ✅ Document navigation link fixes for Jekyll 4 directory structure
- ✅ Add timeline of modernization events
- ✅ Update lessons learned with new insights
- ✅ Mark completed next steps (Ruby upgrade, Jekyll 4, README)

## Key Updates

### Jekyll 4 Upgrade Section
- Crossed out "Why Not Jekyll 4.x" section
- Documented page URL structure changes
- Noted navigation link fixes

### Repository Stats
- Updated file counts (7 files changed)
- Added Dependabot PRs count
- Reflected all merged changes

### Timeline
- Initial modernization
- Dependabot auto-upgrade (+3 hours)
- Local Ruby upgrade and fixes (+30 minutes)

## Testing
- [x] Post builds successfully
- [x] All formatting intact
- [x] Links and code blocks work

## Related PRs
- #3 Initial modernization
- #8 Dependabot Jekyll 4.4.1 upgrade
- #9 Navigation links fix