### PR TITLE
docs: update README to reflect Jekyll 4.4.1 and remove invalid badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A personal technical blog powered by Jekyll and GitHub Pages, featuring articles on Python, Linux, shell scripting, and software development.
 
 [![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-Live-success)](https://hokix.github.io)
-[![Jekyll](https://img.shields.io/badge/Jekyll-3.9.5-red)](https://jekyllrb.com/)
+[![Jekyll](https://img.shields.io/badge/Jekyll-4.4.1-red)](https://jekyllrb.com/)
 [![Deploy Status](https://github.com/hokix/hokix.github.io/actions/workflows/jekyll.yml/badge.svg)](https://github.com/hokix/hokix.github.io/actions/workflows/jekyll.yml)
 
 ## 🌐 Visit


### PR DESCRIPTION
## Summary
Updates README.md to reflect the Jekyll 4.4.1 upgrade and removes the invalid GitHub stats badge.

## Changes
- ✅ Update Jekyll version badge: 3.9.5 → 4.4.1
- ✅ Update tech stack section: Jekyll 4.4.1
- ✅ Update Ruby prerequisites: 3.1+ (was 2.6+)
- ✅ Update dependencies list: Jekyll ~> 4.4.1
- ✅ Remove invalid GitHub stats badge link

## Testing
- [x] All badge links work correctly
- [x] Version numbers consistent throughout README
- [x] No broken links

## Related
- #8 Dependabot Jekyll 4.4.1 upgrade
- #10 Updated blog post with Jekyll 4 details