### PR TITLE
Exclude AI-GENERATED warnings from index page previews

### DIFF
--- a/_posts/2025-12-26-modernizing-jekyll-blog.md
+++ b/_posts/2025-12-26-modernizing-jekyll-blog.md
@@ -4,6 +4,7 @@ title: Modernizing This Jekyll Blog in 2025
 date: 2025-12-26 16:04:00
 category: jekyll
 tags: jekyll github-pages ci-cd ai-generated
+excerpt: "After nearly two years since the last update, I've modernized this blog's infrastructure. Here's what changed and why."
 ---
 
 > **⚠️ AI-GENERATED CONTENT**  

--- a/_posts/2026-01-05-creating-custom-homebrew-tap-for-legacy-packages.md
+++ b/_posts/2026-01-05-creating-custom-homebrew-tap-for-legacy-packages.md
@@ -4,6 +4,7 @@ title: Creating a Custom Homebrew Tap for Legacy Packages
 date: 2026-01-05 07:10:00
 category: homebrew
 tags: homebrew macos package-management ai-generated
+excerpt: "When Homebrew Core drops support for older versions of packages, you're left with few options: upgrade your workflow, build from source manually, or maintain your own tap. This guide shows how to create a custom Homebrew tap for legacy packages."
 ---
 
 > **⚠️ AI-GENERATED CONTENT**  


### PR DESCRIPTION
Add custom excerpts to AI-generated posts to prevent the warning message from appearing in the index page preview while keeping it visible in the full post content.